### PR TITLE
Fixed unnecessary warning when using IRModel

### DIFF
--- a/train.py
+++ b/train.py
@@ -198,8 +198,6 @@ def train_pipeline(root_path):
 
             # validation
             if opt.get('val') is not None and (current_iter % opt['val']['val_freq'] == 0):
-                if len(val_loaders) > 1:
-                    logger.warning('Multiple validation datasets are *only* supported by SRModel.')
                 for val_loader in val_loaders:
                     model.validation(val_loader, current_iter, tb_logger, opt['val']['save_img'])
 


### PR DESCRIPTION
Fixed unnecessary warning when using IRModel. When you use Multiple validation datasets with IRModel, 'Multiple validation datasets are *only* supported by SRModel' will appear, but will still work, so it is redundant.